### PR TITLE
refactor: explicit export for the defineCustomElementReact method

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
-export { defineCustomElementReact } from "./defineCustomElementReact";
-
+import { defineCustomElementReact as importedDefineCustomElementReact } from "./defineCustomElementReact";
 import React from "react";
 
 export const ReactCustom = React;
+export const defineCustomElementReact = importedDefineCustomElementReact;


### PR DESCRIPTION
Previously, the defineCustomElementReact method was exported with an Object.defineProperty on exports. That can generate problem with some builder. 